### PR TITLE
Set licence to a gst-supported one

### DIFF
--- a/src/gstviperfx.c
+++ b/src/gstviperfx.c
@@ -1558,7 +1558,7 @@ GST_PLUGIN_DEFINE (
     "viperfx element",
     viperfx_init,
     VERSION,
-    "NonGPL",
+    "Proprietary",
     "GStreamer",
     "http://gstreamer.net/"
 )


### PR DESCRIPTION
See [gstreamer docs](https://gstreamer.freedesktop.org/data/doc/gstreamer/head/gstreamer/html/GstPlugin.html#GstPluginDesc).

`NonGPL` is not a supported license, the plugin won't be loaded. `Proprietary` works.